### PR TITLE
little touch-up for telegram-bot-daemon.sh

### DIFF
--- a/firmware_mod/scripts/telegram-bot-daemon.sh
+++ b/firmware_mod/scripts/telegram-bot-daemon.sh
@@ -86,10 +86,15 @@ main() {
   [ -z "$messageVal" ] && messageAttr="edited_message"
 
   chatId=$(echo "$json" | $JQ -r ".result[0].$messageAttr.chat.id // \"\"")
+  updateId=$(echo "$json" | $JQ -r '.result[0].update_id // ""')
+  if [ "$updateId" != "" ] && [ -z "$chatId" ]; then                                                                           
+  markAsRead $updateId                                                                                 
+  return 0                                                                                             
+  fi;
   [ -z "$chatId" ] && return 0 # no new messages
 
   cmd=$(echo "$json" | $JQ -r ".result[0].$messageAttr.text // \"\"")
-  updateId=$(echo "$json" | $JQ -r '.result[0].update_id // ""')
+  
 
   if [ "$chatId" != "$userChatId" ]; then
     username=$(echo "$json" | $JQ -r ".result[0].$messageAttr.from.username // \"\"")


### PR DESCRIPTION
My bot sometimes receives a non-message json (spam I think) like this:

{"ok":true,"result":[{"update_id":271754855, "channel_post":{"message_id":73,"chat" ......

in that case updateId has a value and chatId is empty so the markAsRead is never performed.

In order to avoid that some non-message confusing the bot I propose to insert an additional check.